### PR TITLE
Dockerfile: Don't install matplotlib

### DIFF
--- a/docker/Dockerfile.kinetic
+++ b/docker/Dockerfile.kinetic
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     && apt-get clean \
     # pip
     && pip install setuptools wheel \
-    && pip install 'matplotlib==2.2.2' --force-reinstall \
     # cleanup
     && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -9,7 +9,6 @@ from __future__ import print_function
 ######################################################
 """
 REQUIREMENTS:
-matplotlib==2.2.2
 simplejson==3.16.0
 numpy==1.14.1
 opencv_python==3.4.3.18


### PR DESCRIPTION
This used to work, but now it tries to install numpy 1.17, which
requires python >= 3.5, so building the Dockerfile fails. Since we don't
use matplotlib anyway, this commit removes it.