### PR TITLE
Publish camera_info topic for rgb_points

### DIFF
--- a/nodes/dope
+++ b/nodes/dope
@@ -174,6 +174,12 @@ class DopeNode(object):
                 ImageSensor_msg,
                 queue_size=10
             )
+        self.pub_camera_info = \
+            rospy.Publisher(
+                rospy.get_param('~topic_publishing') + "/camera_info",
+                CameraInfo,
+                queue_size=10
+            )
         self.pub_detections = \
             rospy.Publisher(
                 '~detected_objects',
@@ -300,12 +306,10 @@ class DopeNode(object):
                     draw.draw_cube(points2d, self.draw_colors[m])
 
         # Publish the image with results overlaid
-        self.pub_rgb_dope_points.publish(
-            CvBridge().cv2_to_imgmsg(
-                np.array(im)[..., ::-1],
-                "bgr8"
-            )
-        )
+        rgb_points_img = CvBridge().cv2_to_imgmsg(np.array(im)[..., ::-1], "bgr8")
+        rgb_points_img.header = camera_info.header
+        self.pub_rgb_dope_points.publish(rgb_points_img)
+        self.pub_camera_info.publish(camera_info)
         self.pub_detections.publish(detection_array)
         self.publish_markers(detection_array)
 


### PR DESCRIPTION
...and also properly set the time stamp of rgb_points.

This allows visualizing the rgb_points using the Camera display in RViz.

See #119.

This fixes #55 and fixes #70.

Do not merge yet, I haven't been able to test it yet.