### PR TITLE
Update readme + hashbangs

### DIFF
--- a/nodes/camera
+++ b/nodes/camera
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 NVIDIA Corporation. All rights reserved.
 # This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
 # https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode

--- a/nodes/dope
+++ b/nodes/dope
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018 NVIDIA Corporation. All rights reserved.
 # This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ This is the official DOPE ROS package for detection and 6-DoF pose estimation of
 
 ## Installing
 
-We have tested on Ubuntu 18.04 with ROS Noetic with an NVIDIA Titan X and RTX 2080ti with python 3.8.  The code may work on other systems.
+We have tested on Ubuntu 20.04 with ROS Noetic with an NVIDIA Titan X and RTX 2080ti with python 3.8.  The code may work on other systems.
 
 The following steps describe the native installation. Alternatively, use the provided [Docker image](docker/readme.md) and skip to Step #7.
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2018 NVIDIA Corporation. All rights reserved.
 # This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
@@ -31,7 +31,7 @@ HOW TO TRAIN DOPE
 This is the DOPE training code.  
 It is provided as a convenience for researchers, but it is otherwise unsupported.
 
-Please refer to `python train.py --help` for specific details about the 
+Please refer to `python3 train.py --help` for specific details about the 
 training code. 
 
 If you download the FAT dataset 
@@ -39,7 +39,7 @@ If you download the FAT dataset
 you can train a YCB object DOPE detector as follows: 
 
 ```
-python train.py --data path/to/FAT --object soup --outf soup 
+python3 train.py --data path/to/FAT --object soup --outf soup 
 --gpuids 0 1 2 3 4 5 6 7 
 ```
 


### PR DESCRIPTION
Changes:

* Update readme: Ubuntu 18.04 -> 20.04 (ROS Noetic is only available for Ubuntu 20.04)
* Update hashbangs to python3