### PR TITLE
Update ref to new location for isaac_ros_dope

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ We have tested on Ubuntu 20.04 with ROS Noetic with an NVIDIA Titan X and RTX 20
 ---
 ***NOTE***
 
-For hardware-accelerated ROS2 inference support, please visit [Isaac ROS DOPE](https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_dnn_inference/tree/main/isaac_ros_dope) which has been tested with ROS2 Foxy on Jetson AGX Xavier/JetPack 4.6 and on x86/Ubuntu 20.04 with RTX3060i.
+For hardware-accelerated ROS2 inference support, please visit [Isaac ROS DOPE](https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_pose_estimation/tree/main/isaac_ros_dope) which has been tested with ROS2 Foxy on Jetson AGX Xavier/JetPack 4.6 and on x86/Ubuntu 20.04 with RTX3060i.
 
 ---
 


### PR DESCRIPTION
With Isaac ROS EA 2.1, we moved isaac_ros_dope package into a new repository for Isaac ROS Pose Estimation.