### PR TITLE
Fix inference & train

### DIFF
--- a/scripts/train2/inference.py
+++ b/scripts/train2/inference.py
@@ -160,7 +160,7 @@ class DopeNode(object):
 
         # Update camera matrix and distortion coefficients
         if self.input_is_rectified:
-            P = np.matrix(camera_info['camera_matrix']['data'], dtype='float64').copy()
+            P = np.matrix(camera_info['projection_matrix']['data'], dtype='float64').copy()
             P.resize((3, 4))
             camera_matrix = P[:, :3]
             dist_coeffs = np.zeros((4, 1))

--- a/scripts/train2/train.py
+++ b/scripts/train2/train.py
@@ -470,27 +470,27 @@ def _runnetwork(epoch,train_loader,train=True,syn=False):
             # print(stage[0].shape)
             # print(target_affinity_map.shape)
             # raise()
-            # loss_tmp = (( - target_affinity_map) * (stage[0]-target_affinity_map)).mean()/opt.batchsize
+            # loss_tmp = (( - target_affinity_map) * (stage[0]-target_affinity_map)).mean()
 
 
 
-            loss_affinities += ((output_aff[stage] - target_affinities)*(output_aff[stage] - target_affinities)).mean()/opt.batchsize
+            loss_affinities += ((output_aff[stage] - target_affinities)*(output_aff[stage] - target_affinities)).mean()
             
             # print(output_belief[stage].shape)
             # print(target_belief.shape)
 
-            loss_belief += ((output_belief[stage] - target_belief)*(output_belief[stage] - target_belief)).mean()/opt.batchsize
+            loss_belief += ((output_belief[stage] - target_belief)*(output_belief[stage] - target_belief)).mean()
 
-            # loss_tmp = ((stage[1] - target_affinities) * (stage[1]-target_affinities)).mean()/opt.batchsize
+            # loss_tmp = ((stage[1] - target_affinities) * (stage[1]-target_affinities)).mean()
             # loss_affinities += loss_tmp 
 
-            # loss_tmp = ((stage[2] - target_segmentation) * (stage[2]-target_segmentation)).mean()/opt.batchsize
+            # loss_tmp = ((stage[2] - target_segmentation) * (stage[2]-target_segmentation)).mean()
             # loss_segmentation += loss_tmp
 
         # loss = loss_belief + loss_affinities * 0.9 + loss_segmentation * 0.00001
 
         # compute classification loss 
-        # loss_class = ((target_classification.flatten(1) - output_classification) * (target_classification.flatten(1) - output_classification)).mean()/opt.batchsize
+        # loss_class = ((target_classification.flatten(1) - output_classification) * (target_classification.flatten(1) - output_classification)).mean()
         # print(loss_class.item(),loss_belief.item(),loss_affinities.item() )
         loss = loss_affinities + loss_belief
 


### PR DESCRIPTION
Hi @TontonTremblay, I'd like to propose two changes to the train2 code.
1. In [inference.py](https://github.com/NVlabs/Deep_Object_Pose/blob/8402925dfe47d962a1226861b824f0b625893f6c/scripts/train2/inference.py#L163), I think the projection matrix P is not reading the correct matrix "projection_matrix".
2. In [train2.py](https://github.com/NVlabs/Deep_Object_Pose/blob/8402925dfe47d962a1226861b824f0b625893f6c/scripts/train2/train.py#L477), I'm not sure whether we should divide the loss by batchsize. But I think there are two drawbacks for doing that. (1) The loss value will depend on the batchsize; (2) A wrong batchsize (not testbatchsize) is used during testing. But if there was a good reason for doing so or there is a better fix, please let me know. Thank you!!