### PR TITLE
change downscale height

### DIFF
--- a/scripts/train2/config_inference/config_pose.yaml
+++ b/scripts/train2/config_inference/config_pose.yaml
@@ -2,7 +2,7 @@ topic_camera: "/dope/webcam/image_raw"
 topic_camera_info: "/dope/webcam/camera_info"
 topic_publishing: "dope"
 input_is_rectified: True   # Whether the input image is rectified (strongly suggested!)
-downscale_height: 500      # if the input image is larger than this, scale it down to this pixel height
+downscale_height: 400      # if the input image is larger than this, scale it down to this pixel height
 
 # Comment any of these lines to prevent detection / pose estimation of that object
 weights: {


### PR DESCRIPTION
Hi @TontonTremblay, changing the downscale height in config improves the inference result by a lot. I have no idea why. But I guess it may have something to do with [this data augmentation](https://github.com/NVlabs/Deep_Object_Pose/blob/4e0b6b19573b973dca7264d3d94c54ccb193932a/scripts/train2/utils_dope.py#L260)? 