### PR TITLE
train.py: Also look for images in non-leaf folders

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -361,8 +361,7 @@ def loadimages(root):
         if len(folders)>0:
             for path_entry in folders:                
                 explore(path_entry)
-        else:
-            add_json_files(path)
+        add_json_files(path)
 
     explore(root)
 


### PR DESCRIPTION
This is a fix for the problem described in #212.

The problem was that the `loadimages` function only looked for images in the leaf folders of the dataset root, i.e., in those folders that do not have any subfolders. If a folder gets created inside one of those leaf folders (like `.ipynb_checkpoints` in #212), then that became the new leaf folder, and the images in the parent folder are ignored.

This commit changes this behavior so that images in intermediate folders are no longer ignored.