### PR TITLE
nvisii: Change centroid order to be like NDDS/DOPE

### DIFF
--- a/scripts/nvisii_data_gen/utils.py
+++ b/scripts/nvisii_data_gen/utils.py
@@ -919,21 +919,16 @@ def add_cuboid(name, scale=1, debug=False):
 
 
     cuboid = [
-        visii.vec3(max_obj[0], max_obj[1], max_obj[2]),
-        visii.vec3(min_obj[0], max_obj[1], max_obj[2]),
         visii.vec3(max_obj[0], min_obj[1], max_obj[2]),
+        visii.vec3(max_obj[0], max_obj[1], max_obj[2]),
         visii.vec3(max_obj[0], max_obj[1], min_obj[2]),
-        visii.vec3(min_obj[0], min_obj[1], max_obj[2]),
         visii.vec3(max_obj[0], min_obj[1], min_obj[2]),
+        visii.vec3(min_obj[0], min_obj[1], max_obj[2]),
+        visii.vec3(min_obj[0], max_obj[1], max_obj[2]),
         visii.vec3(min_obj[0], max_obj[1], min_obj[2]),
         visii.vec3(min_obj[0], min_obj[1], min_obj[2]),
         visii.vec3(centroid_obj[0], centroid_obj[1], centroid_obj[2]), 
     ]
-
-    # change the ids to be like ndds / DOPE
-    cuboid = [  cuboid[2],cuboid[0],cuboid[3],
-                cuboid[5],cuboid[4],cuboid[1],
-                cuboid[6],cuboid[7],cuboid[-1]]
 
     # same colors as nvdu_viz
     cuboid_colors = [

--- a/scripts/nvisii_data_gen/utils.py
+++ b/scripts/nvisii_data_gen/utils.py
@@ -920,38 +920,26 @@ def add_cuboid(name, scale=1, debug=False):
     The order of the indexes is the same as NVidia Deep learning Dataset Synthesizer (NDDS),
     nvdu_viz from NVidia Dataset Utilities and DOPE.
 
-    The indexes of the 3D bounding cuboid are in the following order:
+    The indexes of the 3D bounding cuboid are in the order shown in the sketch
+    below (0..7), with the object being in its neutral orientation (X axis pointing
+    forward, Y left, Z up).
 
-    - `FrontTopRight` [0]
-    - `FrontTopLeft` [1]
-    - `FrontBottomLeft` [2]
-    - `FrontBottomRight` [3]
-    - `RearTopRight` [4]
-    - `RearTopLeft` [5]
-    - `RearBottomLeft` [6]
-    - `RearBottomRight` [7]
+       (m) 3 +-----------------+ 0 (b)
+            /                 /|
+           /                 / |
+    (m) 2 +-----------------+ 1| (b)
+          |                 |  |
+          |       ^ z       |  |
+          |       |         |  |
+          |  y <--x         |  |
+      (y) |                 |  + 4 (g)
+          |                 | /
+          |                 |/
+    (y) 6 +-----------------+ 5 (g)
 
-    The XYZ coordinate frames are attached to each object as if the object were a
-    camera facing the world through the front.  In other words, from the point of
-    view of viewing the front from inside the object, the X axis points to the
-    right, the Y axis points down, and the Z axis points forward toward the world.
-    Alternatively, from the point of view of viewing the front of the object from
-    the outside (shown below), the X axis points left, the Y axis points down, and
-    the Z axis points out of the page toward the viewer (right-hand coordinate
-    system).
-
-          4 +-----------------+ 5
-           /     TOP         /|
-          /                 / |
-       0 +-----------------+ 1|
-         |      FRONT      |  |
-         |                 |  |
-         |  x <--+         |  |
-         |       |         |  |
-         |       v         |  + 6
-         |        y        | /
-         |                 |/
-       3 +-----------------+ 2
+    Debug markers for the cuboid corners can be rendered using the `--debug` option,
+    with (b) = blue, (m) = magenta, (g) = green, (y) = yellow and the centroid being
+    white.
     """
     obj = visii.entity.get(name)
 

--- a/scripts/nvisii_data_gen/utils.py
+++ b/scripts/nvisii_data_gen/utils.py
@@ -911,23 +911,64 @@ random_texture_material.textures = []
 ######## NDDS ##########
 
 def add_cuboid(name, scale=1, debug=False):
+    """
+    Computes the 3D bounding cuboid for object `name` and the centroid, adds the
+    corresponding child transforms to the object (which will later be used in
+    `get_cuboid_image_space`), and optionally adds small spheres as debug markers
+    to the scene.
+
+    The order of the indexes is the same as NVidia Deep learning Dataset Synthesizer (NDDS),
+    nvdu_viz from NVidia Dataset Utilities and DOPE.
+
+    The indexes of the 3D bounding cuboid are in the following order:
+
+    - `FrontTopRight` [0]
+    - `FrontTopLeft` [1]
+    - `FrontBottomLeft` [2]
+    - `FrontBottomRight` [3]
+    - `RearTopRight` [4]
+    - `RearTopLeft` [5]
+    - `RearBottomLeft` [6]
+    - `RearBottomRight` [7]
+
+    The XYZ coordinate frames are attached to each object as if the object were a
+    camera facing the world through the front.  In other words, from the point of
+    view of viewing the front from inside the object, the X axis points to the
+    right, the Y axis points down, and the Z axis points forward toward the world.
+    Alternatively, from the point of view of viewing the front of the object from
+    the outside (shown below), the X axis points left, the Y axis points down, and
+    the Z axis points out of the page toward the viewer (right-hand coordinate
+    system).
+
+          4 +-----------------+ 5
+           /     TOP         /|
+          /                 / |
+       0 +-----------------+ 1|
+         |      FRONT      |  |
+         |                 |  |
+         |  x <--+         |  |
+         |       |         |  |
+         |       v         |  + 6
+         |        y        | /
+         |                 |/
+       3 +-----------------+ 2
+    """
     obj = visii.entity.get(name)
 
     min_obj = obj.get_mesh().get_min_aabb_corner()
     max_obj = obj.get_mesh().get_max_aabb_corner()
     centroid_obj = obj.get_mesh().get_aabb_center()
 
-
     cuboid = [
         visii.vec3(max_obj[0], min_obj[1], max_obj[2]),
-        visii.vec3(max_obj[0], max_obj[1], max_obj[2]),
-        visii.vec3(max_obj[0], max_obj[1], min_obj[2]),
-        visii.vec3(max_obj[0], min_obj[1], min_obj[2]),
         visii.vec3(min_obj[0], min_obj[1], max_obj[2]),
         visii.vec3(min_obj[0], max_obj[1], max_obj[2]),
-        visii.vec3(min_obj[0], max_obj[1], min_obj[2]),
+        visii.vec3(max_obj[0], max_obj[1], max_obj[2]),
+        visii.vec3(max_obj[0], min_obj[1], min_obj[2]),
         visii.vec3(min_obj[0], min_obj[1], min_obj[2]),
-        visii.vec3(centroid_obj[0], centroid_obj[1], centroid_obj[2]), 
+        visii.vec3(min_obj[0], max_obj[1], min_obj[2]),
+        visii.vec3(max_obj[0], max_obj[1], min_obj[2]),
+        visii.vec3(centroid_obj[0], centroid_obj[1], centroid_obj[2]),
     ]
 
     # same colors as nvdu_viz
@@ -958,8 +999,6 @@ def add_cuboid(name, scale=1, debug=False):
     for i_v, v in enumerate(cuboid):
         cuboid[i_v]=[v[0], v[1], v[2]]
 
-
-     
     return cuboid
 
 def get_cuboid_image_space(obj_id, camera_name = 'my_camera'):


### PR DESCRIPTION
The order of centroid corners in the nvisii training data generation script was wrong. This PR changes the order to the one used in NVidia Dataset Synthesizer (NDSS) and DOPE.