### PR TITLE
Update cmake_minimum_required version to fix warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.2)
 project(dope)
 
 ## Compile as C++11, supported in ROS Kinetic and newer


### PR DESCRIPTION
This fixes the following warning:

    Policy CMP0048 is not set: project() command manages VERSION variables.
    Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.